### PR TITLE
yield the login action

### DIFF
--- a/addon/authenticators/mock-login.js
+++ b/addon/authenticators/mock-login.js
@@ -21,7 +21,7 @@ export default class MockLoginAuthenticator extends BaseAuthenticator {
       throw result;
   }
 
-  async authenticate(account, group) {
+  async authenticate(accountId, groupId) {
     const result = await fetch(basePath, {
       method: 'POST',
       body: JSON.stringify({
@@ -29,13 +29,13 @@ export default class MockLoginAuthenticator extends BaseAuthenticator {
           relationships: {
             account:{
               data: {
-                id: account.get('id'),
+                id: accountId,
                 type: "accounts"
               }
             },
             group: {
               data: {
-                id: group.get('id'),
+                id: groupId,
                 type: "groups"
               }
             }

--- a/addon/components/login/each-account.hbs
+++ b/addon/components/login/each-account.hbs
@@ -1,7 +1,7 @@
 <div ...attributes>
   {{#each @accounts as |account|}}
     {{!template-lint-disable no-inline-styles no-invalid-interactive}}
-    <div style="cursor: pointer;" {{on "click" (fn this.login account)}}>
+    <div style="cursor: pointer;" {{on "click" (fn @login account.id account.gebruiker.group.id)}}>
       {{yield account}}
     </div>
   {{/each}}

--- a/addon/components/login/each-account.js
+++ b/addon/components/login/each-account.js
@@ -1,9 +1,3 @@
-import Component from '@glimmer/component';
-import { action } from '@ember/object';
+import templateOnly from '@ember/component/template-only';
 
-export default class EachAccountComponent extends Component {
-  @action
-  login(account) {
-    this.args.login(account);
-  }
-}
+export default templateOnly();

--- a/addon/components/mock-login.hbs
+++ b/addon/components/mock-login.hbs
@@ -3,6 +3,7 @@
     errorMessage=this.errorMessage
     loading=this.loginTask.isRunning
     isLoading=this.loginTask.isRunning
+    login=(perform this.loginTask)
     each-account=(component 'login/each-account' login=(perform this.loginTask))
   )}}
 </div>

--- a/addon/components/mock-login.js
+++ b/addon/components/mock-login.js
@@ -11,13 +11,11 @@ export default class MockLoginComponent extends Component {
   // This uses the "not so clean" alternative to support both ember-concurrency v1 and v2
   // without having to install ember-concurrency-decorators.
   // TODO: use "pretty" decorators once all projects are using ember-concurrency v2
-  @(task(function*(account) {
+  @(task(function*(accountId, groupId) {
     this.errorMessage = '';
 
     try {
-      const user = yield account.get('gebruiker');
-      const group = yield user.get('group');
-      yield this.session.authenticate('authenticator:mock-login', account, group);
+      yield this.session.authenticate('authenticator:mock-login', accountId, groupId);
     }
     catch(response) {
       if (response instanceof Response)

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -14,7 +14,8 @@ export default class ApplicationController extends Controller {
         firstName: 'Jane',
         lastName: 'Doe',
         group: EmberObject.create({
-          id: '5ac63f89ea27dc000101cf74'
+          id: '5ac63f89ea27dc000101cf74',
+          name: "Beheerder"
         })
       })
     }),
@@ -26,7 +27,8 @@ export default class ApplicationController extends Controller {
         firstName: 'Jimmy',
         lastName: 'Janssens',
         group: EmberObject.create({
-          id: '5ac63f89ea27dc000101cf7c'
+          id: '5ac63f89ea27dc000101cf7c',
+          name: "Werknemer"
         })
       })
     })

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -14,9 +14,22 @@
         {{login.errorMessage}}
       {{/if}}
 
+      <h2>Use the each-account component</h2>
       <login.each-account @accounts={{this.accounts}} as |account|>
-        {{account.gebruiker.firstName}} {{account.gebruiker.lastName}} {{account.gebruiker.groep.name}}
+        <strong>{{account.gebruiker.firstName}} {{account.gebruiker.lastName}}</strong> {{account.gebruiker.group.name}}
       </login.each-account>
+
+
+      <h2>or bring your own html!</h2>
+      <ul>
+        {{#each this.accounts as |account|}}
+          <li>
+            <button type="button" {{on "click" (fn login.login account.id account.gebruiker.group.id)}}>
+              <strong>{{account.gebruiker.firstName}} {{account.gebruiker.lastName}}</strong> {{account.gebruiker.group.name}}
+            </button>
+          </li>
+        {{/each}}
+      </ul>
     {{/if}}
   </MockLogin>
 {{/if}}


### PR DESCRIPTION
(Builds on #5. Needs to be rebased once that one is merged)

The MockLogin component now also yields the login action. This has a few benefits:

- The EachAccount component uses `<div>` elements with click handlers which isn't recommended. Apps can now use custom html and use the login action directly.
- The host app can pass in the needed ids without having to use the same Model / relationship naming that was hard coded into the addon.