### PR TITLE
Allow apps to use ember-simple-auth v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-cli-htmlbars": "^5.7.1",
     "ember-concurrency": "^1.0.0 || ^2.0.1",
     "ember-fetch": "^8.0.4",
-    "ember-simple-auth": "^3.1.0"
+    "ember-simple-auth": "^3.1.0 || ^4.2.1"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",


### PR DESCRIPTION
The v4 release only drops node 10 support so we can safely depend on it here.