### PR TITLE
Make ember-simple-auth a peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "ember-cli-babel": "^7.26.3",
         "ember-cli-htmlbars": "^5.7.1",
         "ember-concurrency": "^1.0.0 || ^2.0.1",
-        "ember-fetch": "^8.0.4",
-        "ember-simple-auth": "^3.1.0 || ^4.2.1"
+        "ember-fetch": "^8.0.4"
       },
       "devDependencies": {
         "@ember/optional-features": "^2.0.0",
@@ -36,6 +35,7 @@
         "ember-page-title": "^6.2.1",
         "ember-qunit": "^5.1.4",
         "ember-resolver": "^8.0.2",
+        "ember-simple-auth": "^6.0.0",
         "ember-source": "~3.26.1",
         "ember-source-channel-url": "^3.0.0",
         "ember-template-lint": "^3.2.0",
@@ -56,6 +56,9 @@
       },
       "engines": {
         "node": "10.* || >= 12"
+      },
+      "peerDependencies": {
+        "ember-simple-auth": "^6.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -2296,6 +2299,20 @@
       },
       "engines": {
         "node": "10.* || 12.* || >= 14.*"
+      }
+    },
+    "node_modules/@embroider/addon-shim": {
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/@embroider/addon-shim/-/addon-shim-1.8.7.tgz",
+      "integrity": "sha512-JGOQNRj3UR0NdWEg8MsM2eqPLncEwSB1IX+rwntIj22TEKj8biqx7GDgSbeH+ZedijmCh354Hf2c5rthrdzUAw==",
+      "dev": true,
+      "dependencies": {
+        "@embroider/shared-internals": "^2.5.1",
+        "broccoli-funnel": "^3.0.8",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "12.* || 14.* || >= 16"
       }
     },
     "node_modules/@embroider/macros": {
@@ -5401,11 +5418,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
-    },
     "node_modules/base/node_modules/define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
@@ -6275,6 +6287,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz",
       "integrity": "sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==",
+      "dev": true,
       "dependencies": {
         "broccoli-plugin": "^1.1.0",
         "mkdirp": "^0.5.1"
@@ -6287,6 +6300,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6295,6 +6309,7 @@
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -10704,7 +10719,8 @@
     "node_modules/ember-cli-is-package-missing": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/ember-cli-is-package-missing/-/ember-cli-is-package-missing-1.0.0.tgz",
-      "integrity": "sha512-9hEoZj6Au5onlSDdcoBqYEPT8ehlYntZPxH8pBKV0GO7LNel88otSAQsCfXvbi2eKE+MaSeLG/gNaCI5UdWm9g=="
+      "integrity": "sha512-9hEoZj6Au5onlSDdcoBqYEPT8ehlYntZPxH8pBKV0GO7LNel88otSAQsCfXvbi2eKE+MaSeLG/gNaCI5UdWm9g==",
+      "dev": true
     },
     "node_modules/ember-cli-lodash-subset": {
       "version": "2.0.1",
@@ -11261,15 +11277,15 @@
       }
     },
     "node_modules/ember-cookies": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-0.5.2.tgz",
-      "integrity": "sha512-nZ7oG97kBcO9UHjO95ryABpnVx62Bhxo7lIsBJNmWvFXleILm9DGueiAynzXxuYWWPuKIeeSbYakrS1869tNTw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cookies/-/ember-cookies-1.1.1.tgz",
+      "integrity": "sha512-72GsE2ibwUeEMoLa8yggF+Y5+W/koVG9vU166pnM8HFTsZKLC6RSIfWnkkGmJva06yPKPgusmymAatF+5hjjjQ==",
+      "dev": true,
       "dependencies": {
-        "ember-cli-babel": "^7.1.0",
-        "ember-getowner-polyfill": "^1.1.0 || ^2.0.0"
+        "@embroider/addon-shim": "^1.7.1"
       },
       "engines": {
-        "node": "8.* || 10.* || >= 12.*"
+        "node": ">= 16.*"
       }
     },
     "node_modules/ember-destroyable-polyfill": {
@@ -11301,37 +11317,6 @@
       "dev": true,
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.3.1.tgz",
-      "integrity": "sha512-y3iG2iCzH96lZMTWQw6LWNLAfOmDC4pXKbZP6FxG8lt7GGaNFkZjwsf+Z5GAe7kxfD7UG4lVkF7x37K82rySGA==",
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-factory-for-polyfill/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/ember-fetch": {
@@ -11493,38 +11478,6 @@
       },
       "engines": {
         "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-getowner-polyfill/-/ember-getowner-polyfill-2.2.0.tgz",
-      "integrity": "sha512-rwGMJgbGzxIAiWYjdpAh04Abvt0s3HuS/VjHzUFhVyVg2pzAuz45B9AzOxYXzkp88vFC7FPaiA4kE8NxNk4A4Q==",
-      "dependencies": {
-        "ember-cli-version-checker": "^2.1.0",
-        "ember-factory-for-polyfill": "^1.3.1"
-      },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/ember-cli-version-checker": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-      "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-      "dependencies": {
-        "resolve": "^1.3.3",
-        "semver": "^5.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/ember-getowner-polyfill/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/ember-load-initializers": {
@@ -13109,130 +13062,25 @@
       }
     },
     "node_modules/ember-simple-auth": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-4.2.2.tgz",
-      "integrity": "sha512-D7W6OREUvf5OzeB0ePptSNBilccchRYukH4f7mkbL6WT+z6VEqRRAIaQuBZdFM6lrcSFGmzctINLZJwsIpI3wg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ember-simple-auth/-/ember-simple-auth-6.0.0.tgz",
+      "integrity": "sha512-9SzSFApxZ74CD4UxIeTV+poIPeXcRLXWM60cMvC1SwTYjoc/p9DeQF0pVm6m1XV6uA3kPUzEsEn4/GeHc2YX1w==",
+      "dev": true,
       "dependencies": {
-        "base-64": "^0.1.0",
-        "broccoli-file-creator": "^2.1.1",
-        "broccoli-funnel": "^1.2.0 || ^2.0.0",
-        "broccoli-merge-trees": "^4.0.0",
-        "ember-cli-babel": "^7.20.5",
+        "@ember/test-waiters": "^3",
+        "@embroider/addon-shim": "^1.0.0",
+        "@embroider/macros": "^1.0.0",
         "ember-cli-is-package-missing": "^1.0.0",
-        "ember-cookies": "^0.5.0",
+        "ember-cookies": "^1.0.0",
         "silent-error": "^1.0.0"
       },
-      "engines": {
-        "node": ">= 12"
-      },
       "peerDependencies": {
-        "ember-fetch": "^8.0.1"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-funnel": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
-      "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-      "dependencies": {
-        "array-equal": "^1.0.0",
-        "blank-object": "^1.0.1",
-        "broccoli-plugin": "^1.3.0",
-        "debug": "^2.2.0",
-        "fast-ordered-set": "^1.0.0",
-        "fs-tree-diff": "^0.5.3",
-        "heimdalljs": "^0.2.0",
-        "minimatch": "^3.0.0",
-        "mkdirp": "^0.5.0",
-        "path-posix": "^1.0.0",
-        "rimraf": "^2.4.3",
-        "symlink-or-copy": "^1.0.0",
-        "walk-sync": "^0.3.1"
+        "@ember/test-helpers": ">= 3 || > 2.7"
       },
-      "engines": {
-        "node": "^4.5 || 6.* || >= 7.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-merge-trees": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-4.2.0.tgz",
-      "integrity": "sha512-nTrQe5AQtCrW4enLRvbD/vTLHqyW2tz+vsLXQe4IEaUhepuMGVKJJr+I8n34Vu6fPjmPLwTjzNC8izMIDMtHPw==",
-      "dependencies": {
-        "broccoli-plugin": "^4.0.2",
-        "merge-trees": "^2.0.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-merge-trees/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/broccoli-merge-trees/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ember-simple-auth/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/ember-simple-auth/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "engines": {
-        "node": "10.* || >= 12.*"
+      "peerDependenciesMeta": {
+        "@ember/test-helpers": {
+          "optional": true
+        }
       }
     },
     "node_modules/ember-source": {

--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
     "ember-cli-babel": "^7.26.3",
     "ember-cli-htmlbars": "^5.7.1",
     "ember-concurrency": "^1.0.0 || ^2.0.1",
-    "ember-fetch": "^8.0.4",
-    "ember-simple-auth": "^3.1.0 || ^4.2.1"
+    "ember-fetch": "^8.0.4"
+  },
+  "peerDependencies": {
+    "ember-simple-auth": "^6.0.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^2.0.0",
@@ -54,6 +56,7 @@
     "ember-page-title": "^6.2.1",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",
+    "ember-simple-auth": "^6.0.0",
     "ember-source": "~3.26.1",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^3.2.0",


### PR DESCRIPTION
This allows the consuming app to decide on the version.

Breaking change since apps need to define the version and we require v6 now.