### PR TITLE
Remove the wrapping div from the `<MockLogin>` component

### DIFF
--- a/addon/components/mock-login.hbs
+++ b/addon/components/mock-login.hbs
@@ -1,8 +1,8 @@
-<div ...attributes>
-  {{yield (hash
+{{yield
+  (hash
     errorMessage=this.errorMessage
     loading=this.isRunning
     isLoading=this.isRunning
     login=this.login
-  )}}
-</div>
+  )
+}}


### PR DESCRIPTION
Now the component simply provides data, without outputting any html. Consumers can still add the div element when needed.