### PR TITLE
Fix a timing issue with the authenticator methods in tests

### DIFF
--- a/addon/authenticators/mock-login.js
+++ b/addon/authenticators/mock-login.js
@@ -1,9 +1,12 @@
+import { waitFor } from '@ember/test-waiters';
 import BaseAuthenticator from 'ember-simple-auth/authenticators/base';
+
 const basePath = '/mock/sessions';
 const contentType = 'application/vnd.api+json';
 const supportedCredentials = 'same-origin';
 
 export default class MockLoginAuthenticator extends BaseAuthenticator {
+  @waitFor
   async restore() {
     const url = `${basePath}/current`;
     const result = await fetch(url, {
@@ -17,6 +20,7 @@ export default class MockLoginAuthenticator extends BaseAuthenticator {
     else throw result;
   }
 
+  @waitFor
   async authenticate(accountId, groupId) {
     const result = await fetch(basePath, {
       method: 'POST',
@@ -48,6 +52,7 @@ export default class MockLoginAuthenticator extends BaseAuthenticator {
     else throw result;
   }
 
+  @waitFor
   async invalidate() {
     const url = `${basePath}/current`;
     const result = await fetch(url, {


### PR DESCRIPTION
Removing ember-fetch caused some timing issues in certain test setups. ember-fetch is integrated with Ember's test system, but native fetch is not.

To work around this problem we add the `@waitFor` decorator to the authenticator's lifecycle hooks which means the test system is aware of them again.

I tried reproducing the issue in the test setup here, but I couldn't get it to work properly and didn't want to invest that much extra time.

Fixes #28 